### PR TITLE
Show Analysis compliances based on Projects's Report Preference

### DIFF
--- a/appknox/analyses.go
+++ b/appknox/analyses.go
@@ -97,6 +97,12 @@ type Analysis struct {
 	CvssBase        float64                 `json:"cvss_base,omitempty"`
 	CvssVersion     int                     `json:"cvss_version,omitempty"`
 	Owasp           []string                `json:"owasp,omitempty"`
+	Pcidss          []string                `json:"pcidss,omitempty"`
+	Hipaa           []string                `json:"hipaa,omitempty"`
+	Asvs            []string                `json:"asvs,omitempty"`
+	Cwe             []string                `json:"cwe,omitempty"`
+	Gdpr            []string                `json:"gdpr,omitempty"`
+	Mstg            []string                `json:"mstg,omitempty"`
 	UpdatedOn       *time.Time              `json:"updated_on,omitempty"`
 	VulnerabilityID int                     `json:"vulnerability,omitempty"`
 }

--- a/appknox/analyses_test.go
+++ b/appknox/analyses_test.go
@@ -35,6 +35,32 @@ func TestAnalyses_marshall(t *testing.T) {
 	testJSONMarshal(t, u, want)
 }
 
+func TestAnalysesCompliance_marshall(t *testing.T) {
+	u := &Analysis{
+		ID:              1,
+		Owasp:           []string{"O_1", "O_2"},
+		Pcidss:          []string{"P_1"},
+		Hipaa:           []string{"H_1", "H_2"},
+		Asvs:            []string{"A_1"},
+		Cwe:             []string{"C_1"},
+		Gdpr:            []string{"G_1", "G_2"},
+		Mstg:            []string{"M_1"},
+		VulnerabilityID: 1,
+	}
+	want := `{
+		"id": 1,
+		"owasp": ["O_1", "O_2"],
+		"pcidss": ["P_1"],
+		"hipaa": ["H_1", "H_2"],
+		"asvs": ["A_1"],
+		"cwe": ["C_1"],
+		"gdpr": ["G_1", "G_2"],
+		"mstg": ["M_1"],
+		"vulnerability": 1
+	}`
+	testJSONMarshal(t, u, want)
+}
+
 func TestAnalysesService_ListByFile(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/appknox/appknox.go
+++ b/appknox/appknox.go
@@ -52,6 +52,7 @@ type Client struct {
 	// Files service is used to interact with appknox file api.
 	Files *FilesService
 
+	ProjectProfiles *ProjectProfilesService
 	// Analyses service is used to interact with appknox analyses api.
 	Analyses *AnalysesService
 
@@ -93,6 +94,7 @@ func NewClient(accessToken string) (*Client, error) {
 	c.Projects = (*ProjectsService)(&c.common)
 	c.Files = (*FilesService)(&c.common)
 	c.Analyses = (*AnalysesService)(&c.common)
+	c.ProjectProfiles = (*ProjectProfilesService)(&c.common)
 	c.Vulnerabilities = (*VulnerabilitiesService)(&c.common)
 	c.OWASP = (*OWASPService)(&c.common)
 	c.Organizations = (*OrganizationsService)(&c.common)

--- a/appknox/files.go
+++ b/appknox/files.go
@@ -95,6 +95,7 @@ type File struct {
 	IsManualDone       bool                       `json:"is_manual_done,omitempty"`
 	IsAPIDone          bool                       `json:"is_api_done,omitempty"`
 	CreatedOn          *time.Time                 `json:"created_on,omitempty"`
+	ProfileID          int                        `json:"profile,omitempty"`
 }
 
 // FileListOptions specifies the optional parameters to the

--- a/appknox/files_test.go
+++ b/appknox/files_test.go
@@ -8,6 +8,43 @@ import (
 	"testing"
 )
 
+func TestFiles_marshall(t *testing.T) {
+	testJSONMarshal(t, &File{}, "{}")
+	u := &File{
+		ID:                 1,
+		Name:               "file name",
+		Version:            "1.0",
+		VersionCode:        "1.0",
+		DynamicStatus:      2,
+		APIScanProgress:    1,
+		IsStaticDone:       true,
+		IsDynamicDone:      true,
+		StaticScanProgress: 100,
+		APIScanStatus:      2,
+		Rating:             "4.5",
+		IsManualDone:       true,
+		IsAPIDone:          true,
+		ProfileID:          1,
+	}
+	want := `{
+		"id": 1,
+		"name": "file name",
+		"version": "1.0",
+		"version_code": "1.0",
+		"dynamic_status": 2,
+		"api_scan_progress": 1,
+		"is_static_done": true,
+		"is_dynamic_done": true,
+		"static_scan_progress": 100,
+		"api_scan_status": 2,
+		"rating": "4.5",
+		"is_manual_done": true,
+		"is_api_done": true,
+		"profile": 1
+	}`
+	testJSONMarshal(t, u, want)
+}
+
 func TestFilesService_ListByProject(t *testing.T) {
 	client, mux, _, teardown := setup()
 	defer teardown()

--- a/appknox/project_profile.go
+++ b/appknox/project_profile.go
@@ -1,0 +1,43 @@
+package appknox
+
+import (
+	"context"
+	"fmt"
+)
+
+// ProjectProfileService is used to interact with project profile api.
+type ProjectProfilesService service
+
+type RegulatoryPreference struct {
+	Value bool `json:"value,omitempty"`
+}
+
+// ProjectProfileReportPreference struct is used to validate the response
+// of prpject profile report preference API
+type ProjectProfileReportPreference struct {
+	ShowPcidss RegulatoryPreference `json:"show_pcidss,omitempty"`
+	ShowHipaa  RegulatoryPreference `json:"show_hipaa,omitempty"`
+	ShowGdpr   RegulatoryPreference `json:"show_gdpr,omitempty"`
+}
+
+// CurrentAuthenticatedUser is used to get the details about the current
+// authenticated user at appknox.
+func (s *ProjectProfilesService) GetProjectProfileReportPreference(ctx context.Context, fileID int) (*ProjectProfileReportPreference, *Response, error) {
+	file, resp, err := s.client.Files.GetByID(ctx, fileID)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Get the profile report preference
+	u := fmt.Sprintf("api/profiles/%v/report_preference", file.ProfileID)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	var reportPrefResponse ProjectProfileReportPreference
+	resp, err = s.client.Do(ctx, req, &reportPrefResponse)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &reportPrefResponse, resp, nil
+
+}

--- a/appknox/project_profile_test.go
+++ b/appknox/project_profile_test.go
@@ -1,0 +1,110 @@
+package appknox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRegulatoryPreference_marshall(t *testing.T) {
+	testJSONMarshal(t, &RegulatoryPreference{}, "{}")
+
+	u := &RegulatoryPreference{Value: true}
+	want := `{"value": true}`
+	testJSONMarshal(t, u, want)
+}
+func TestProjectProfileReportPreference_marshall(t *testing.T) {
+	testJSONMarshal(t, &ProjectProfileReportPreference{},
+		`{"show_pcidss":{}, "show_hipaa":{}, "show_gdpr":{}}`)
+
+	u := &ProjectProfileReportPreference{
+		ShowPcidss: RegulatoryPreference{Value: true},
+		ShowHipaa:  RegulatoryPreference{Value: true},
+		ShowGdpr:   RegulatoryPreference{Value: true},
+	}
+	want := `{
+		"show_pcidss": {"value": true},
+		"show_hipaa": {"value": true},
+		"show_gdpr": {"value": true}
+	}`
+	testJSONMarshal(t, u, want)
+}
+
+func TestProjectProfilesService_GetProjectProfileReportPreference(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/files/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "profile": 1}`)
+	})
+	mux.HandleFunc("/api/profiles/1/report_preference", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"show_pcidss": {"value": true},
+			"show_hipaa": {"value": true},
+			"show_gdpr": {"value": false}
+		}`)
+	})
+
+	profileReportPreference, _, err := client.ProjectProfiles.GetProjectProfileReportPreference(context.Background(), 1)
+	if err != nil {
+		t.Errorf("ProjectProfiles.GetProjectProfileReportPreference return error: %v", err)
+	}
+
+	want := &ProjectProfileReportPreference{
+		ShowPcidss: RegulatoryPreference{Value: true},
+		ShowHipaa:  RegulatoryPreference{Value: true},
+		ShowGdpr:   RegulatoryPreference{Value: false},
+	}
+	if !reflect.DeepEqual(profileReportPreference, want) {
+		t.Errorf("ProjectProfiles.GetProjectProfileReportPreference returned %+v, want %+v",
+			profileReportPreference, want)
+	}
+}
+
+func TestProjectProfilesService_GetProjectProfileReportPreference_InvalidFileID(t *testing.T) {
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/files/500", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"Not found."}`)
+	})
+
+	_, resp, err := client.ProjectProfiles.GetProjectProfileReportPreference(context.Background(), 500)
+	if resp != nil {
+		t.Errorf("ProjectProfile Report Preference should be nil for invalid file ID")
+	}
+	if !strings.Contains(err.Error(), "404 Not found") {
+		t.Errorf("Error message is incorrect for invalid file ID")
+	}
+}
+
+func TestProjectProfilesService_GetProjectProfileReportPreference_InvalidProfileID(t *testing.T) {
+	// This situation is virtually impossible but let's test it anyway
+	client, mux, _, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v2/files/500", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":1, "profile": 500}`)
+	})
+	mux.HandleFunc("/api/profiles/500/report_preference", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"Not found."}`)
+	})
+
+	_, resp, err := client.ProjectProfiles.GetProjectProfileReportPreference(context.Background(), 500)
+	if resp != nil {
+		t.Errorf("ProjectProfile Report Preference should be nil for invalid profile ID")
+	}
+	if !strings.Contains(err.Error(), "404 Not found") {
+		t.Errorf("Error message is incorrect for invalid profile ID")
+	}
+}


### PR DESCRIPTION
Affected CLI command: `appknox analyses <file_id>`
The flow to show the list of Analyses for a file is following now:
1. The client will call `GET /api/v2/files/:file_id/analyses` to get the list of analyses objects with all the compliance.
2. The client will then call `GET /api/v2/files/:file_id` to get the project profile ID associated with the file.
3. The client will then call `GET /api/profiles/:profile_id/report_preference` to get the compliance preference for the project.
4. Based the data received from step 3, only those compliance which has to be shown as set from the project setting page will be shown for the analyses in the CLI toll.