### PR TITLE
Adding OWASP Mobile 2024 compliance

### DIFF
--- a/appknox/analyses.go
+++ b/appknox/analyses.go
@@ -107,6 +107,7 @@ type Analysis struct {
 	Masvs           []string                `json:"masvs,omitempty"`
 	Nistsp80053     []string                `json:"nistsp80053,omitempty"`
 	Nistsp800171    []string                `json:"nistsp800171,omitempty"`
+	Owaspmobile2024 []string                `json:"owaspmobile2024,omitempty"`
 	UpdatedOn       *time.Time              `json:"updated_on,omitempty"`
 	VulnerabilityID int                     `json:"vulnerability,omitempty"`
 }

--- a/appknox/analyses_test.go
+++ b/appknox/analyses_test.go
@@ -49,6 +49,7 @@ func TestAnalysesCompliance_marshall(t *testing.T) {
 		Masvs:           []string{"MASVS_6_3"},
 		Nistsp80053:     []string{"AC_3", "RA_2"},
 		Nistsp800171:    []string{"3_1_1", "3_1_3"},
+		Owaspmobile2024: []string{"M6_2024"},
 		VulnerabilityID: 1,
 	}
 	want := `{
@@ -64,6 +65,7 @@ func TestAnalysesCompliance_marshall(t *testing.T) {
 		"masvs": ["MASVS_6_3"],
 		"nistsp80053": ["AC_3", "RA_2"],
 		"nistsp800171": ["3_1_1", "3_1_3"],
+		"owaspmobile2024": ["M6_2024"],
 		"vulnerability": 1
 	}`
 	testJSONMarshal(t, u, want)

--- a/helper/analyses.go
+++ b/helper/analyses.go
@@ -36,7 +36,7 @@ func ProcessAnalyses(fileID int) {
 	// header is an interface because t.AddHeader only supports
 	// interface elements
 	header := []interface{}{"ID", "RISK", "STATUS", "CVSS-VECTOR", "CVSS-BASE", "CVSS-VERSION", "OWASP", "ASVS", "CWE",
-		"MSTG", "OWASP API 2023", "OWASP MASVS (v2)", "NIST SP 800-53", "NIST SP 800-171"}
+		"MSTG", "OWASP API 2023", "OWASP MASVS (v2)", "NIST SP 800-53", "NIST SP 800-171", "OWASP MOBILE 2024"}
 	if profileReportPref.ShowPcidss.Value {
 		header = append(header, "PCI-DSS")
 	}
@@ -66,6 +66,7 @@ func ProcessAnalyses(fileID int) {
 			finalAnalyses[i].Masvs,
 			finalAnalyses[i].Nistsp80053,
 			finalAnalyses[i].Nistsp800171,
+			finalAnalyses[i].Owaspmobile2024,
 		}
 		if profileReportPref.ShowPcidss.Value {
 			row = append(row, finalAnalyses[i].Pcidss)


### PR DESCRIPTION
| Title                          | Value                                                                                     |
| ------------------------------ | ----------------------------------------------------------------------------------------- |
| **Type**                       | Feature |
| **Ticket/Issue**               | [ jira ticket ](https://appknox.atlassian.net/jira/software/c/projects/PD/boards/14?assignee=612b14b1324958007190b8c8&selectedIssue=PD-1184)                                        |
| **Migrations**                 | No |
| **Migration&nbsp;Scripts**     | No |
| **ENV&nbsp;vars&nbsp;change**  | No |
| **Frontend**                   | No |
| **Local&nbsp;testing**         | Done |
| **Staging&nbsp;testing**       | Done |
| **On&nbsp;premise&nbsp;notes** | NA |
| **Documentation**              | [ Confluence design specification document ](https://appknox.atlassian.net/wiki/spaces/TD/pages/2289303567/OWASP+Mobile+Top+10+2024+Compliance+Mappings)                         |
| **Release&nbsp;notes**         | None |
| **Version&nbsp;upgrade**       | Minor |

---

### Changelog

1. Added OWASP Mobile 2024 top 10 compliance
---

#### Dependent PRs

-   [Link to vendor](https://github.com/appknox/vendor/pull/144)
-   [Link to mycroft](https://github.com/appknox/mycroft/pull/1762)