### PR TITLE
timeout support added

### DIFF
--- a/appknox/sarif_generator.go
+++ b/appknox/sarif_generator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
+	"github.com/spf13/viper"
 )
 
 type SARIF struct {
@@ -109,7 +110,7 @@ func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SA
 			decor.Name("] "),
 		),
 	)
-
+	
 	for sarifReportProgess < 100 {
 		file, _, err := client.Files.GetByID(ctx, fileID)
 		if err != nil {
@@ -118,7 +119,8 @@ func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SA
 		}
 		sarifReportProgess = file.StaticScanProgress
 		bar.SetCurrent(int64(sarifReportProgess), time.Since(start))
-		if time.Since(start) > 15*time.Minute {
+		
+		if time.Since(start) > time.Duration(viper.GetInt("timeout")) * time.Minute {
 			err := errors.New("Request timed out")
 			PrintError(err)
 			os.Exit(1)

--- a/appknox/sarif_generator.go
+++ b/appknox/sarif_generator.go
@@ -13,7 +13,6 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
-	"github.com/spf13/viper"
 )
 
 type SARIF struct {
@@ -120,7 +119,7 @@ func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SA
 		sarifReportProgess = file.StaticScanProgress
 		bar.SetCurrent(int64(sarifReportProgess), time.Since(start))
 		
-		if time.Since(start) > time.Duration(viper.GetInt("timeout")) * time.Minute {
+		if time.Since(start) > 15*time.Minute {
 			err := errors.New("Request timed out")
 			PrintError(err)
 			os.Exit(1)

--- a/appknox/sarif_generator.go
+++ b/appknox/sarif_generator.go
@@ -90,7 +90,7 @@ type Help struct {
 	Markdown string `json:"markdown,omitempty"`
 }
 
-func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SARIF, error) {
+func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int,staticScanTimeout time.Duration) (SARIF, error) {
 	ctx := context.Background()
 	var sarifReportProgess int
 	start := time.Now()
@@ -119,7 +119,7 @@ func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SA
 		sarifReportProgess = file.StaticScanProgress
 		bar.SetCurrent(int64(sarifReportProgess), time.Since(start))
 		
-		if time.Since(start) > 15*time.Minute {
+		if time.Since(start) > staticScanTimeout {
 			err := errors.New("Request timed out")
 			PrintError(err)
 			os.Exit(1)
@@ -264,7 +264,7 @@ func GenerateSARIFGivenFileID(client *Client, fileID int, riskThreshold int) (SA
 }
 
 func PrintError(err error) {
-	panic("unimplemented")
+	panic(err)
 }
 
 func GenerateSARIFFileContent(sarif SARIF) (string, error) {

--- a/cmd/cicheck.go
+++ b/cmd/cicheck.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/appknox/appknox-go/helper"
 	"github.com/spf13/cobra"
@@ -45,7 +46,10 @@ var cicheckCmd = &cobra.Command{
 			helper.PrintError(err)
 			os.Exit(1)
 		}
-		helper.ProcessCiCheck(fileID, riskThresholdInt)
+		timeoutMinutes, _ := cmd.Flags().GetInt("sast-timeout")
+		timeout := time.Duration(timeoutMinutes) * time.Minute
+		
+		helper.ProcessCiCheck(fileID, riskThresholdInt, timeout)
 	},
 }
 
@@ -53,4 +57,7 @@ func init() {
 	RootCmd.AddCommand(cicheckCmd)
 	cicheckCmd.Flags().StringP(
 		"risk-threshold", "r", "low", "Risk threshold to fail the command. Available options: low, medium, high")
+	cicheckCmd.Flags().IntP(
+			"sast-timeout", "t", 30, "Timeout in minutes for the CI check (default: 30)")
+	
 }

--- a/cmd/cicheck.go
+++ b/cmd/cicheck.go
@@ -46,7 +46,7 @@ var cicheckCmd = &cobra.Command{
 			helper.PrintError(err)
 			os.Exit(1)
 		}
-		timeoutMinutes, _ := cmd.Flags().GetInt("sast-timeout")
+		timeoutMinutes, _ := cmd.Flags().GetInt("timeout")
 		timeout := time.Duration(timeoutMinutes) * time.Minute
 		
 		helper.ProcessCiCheck(fileID, riskThresholdInt, timeout)
@@ -58,6 +58,6 @@ func init() {
 	cicheckCmd.Flags().StringP(
 		"risk-threshold", "r", "low", "Risk threshold to fail the command. Available options: low, medium, high")
 	cicheckCmd.Flags().IntP(
-			"sast-timeout", "t", 30, "Static scan timeout in minutes for the CI check (default: 30)")
+			"timeout", "t", 30, "Static scan timeout in minutes for the CI check (default: 30)")
 	
 }

--- a/cmd/cicheck.go
+++ b/cmd/cicheck.go
@@ -58,6 +58,6 @@ func init() {
 	cicheckCmd.Flags().StringP(
 		"risk-threshold", "r", "low", "Risk threshold to fail the command. Available options: low, medium, high")
 	cicheckCmd.Flags().IntP(
-			"sast-timeout", "t", 30, "Timeout in minutes for the CI check (default: 30)")
+			"sast-timeout", "t", 30, "Static scan timeout in minutes for the CI check (default: 30)")
 	
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,10 +40,6 @@ func init() {
     viper.BindEnv("host", "APPKNOX_API_HOST")
 
 	// Define flags globally here for all subcommands
-	RootCmd.PersistentFlags().String("timeout", "", "Timeout for Appknox scanner, default is 30 minutes")
-	viper.BindPFlag("timeout", RootCmd.PersistentFlags().Lookup("timeout"))
-	viper.BindEnv("timeout", "APPKNOX_TIMEOUT")
-	viper.SetDefault("timeout", "30") // Default to 30 minutes
 	RootCmd.PersistentFlags().String("region", "", "Region names, e.g., global, saudi, uae. By default, global is used")
     viper.BindPFlag("region", RootCmd.PersistentFlags().Lookup("region"))
     viper.BindEnv("region", "APPKNOX_API_REGION")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
+	
 	// "github.com/appknox/appknox-go/appknox"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -39,7 +39,11 @@ func init() {
     viper.BindPFlag("host", RootCmd.PersistentFlags().Lookup("host"))
     viper.BindEnv("host", "APPKNOX_API_HOST")
 
-
+	// Define flags globally here for all subcommands
+	RootCmd.PersistentFlags().String("timeout", "", "Timeout for Appknox scanner, default is 30 minutes")
+	viper.BindPFlag("timeout", RootCmd.PersistentFlags().Lookup("timeout"))
+	viper.BindEnv("timeout", "APPKNOX_TIMEOUT")
+	viper.SetDefault("timeout", "30") // Default to 30 minutes
 	RootCmd.PersistentFlags().String("region", "", "Region names, e.g., global, saudi, uae. By default, global is used")
     viper.BindPFlag("region", RootCmd.PersistentFlags().Lookup("region"))
     viper.BindEnv("region", "APPKNOX_API_REGION")

--- a/cmd/sarif.go
+++ b/cmd/sarif.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
+	"time"
+	
 	"github.com/appknox/appknox-go/helper"
 	"github.com/spf13/cobra"
 )
@@ -45,7 +46,9 @@ var sarifCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		outputFilePath, _ := cmd.Flags().GetString("output")
-		helper.ConvertToSARIFReport(fileID,riskThresholdInt,outputFilePath)
+		timeoutMinutes, _ := cmd.Flags().GetInt("timeout")
+		timeout := time.Duration(timeoutMinutes) * time.Minute
+		helper.ConvertToSARIFReport(fileID,riskThresholdInt,outputFilePath,timeout)
 	},
 }
 
@@ -54,4 +57,6 @@ func init() {
 	sarifCmd.Flags().StringP(
 		"risk-threshold", "r", "low", "Risk threshold to fail the command. Available options: low, medium, high")
 	sarifCmd.PersistentFlags().StringP("output", "o", "report.sarif", "Output file path to save reports")
+	sarifCmd.Flags().IntP(
+		"timeout", "t", 30, "Static scan timeout in minutes for the CI check (default: 30)")
 }

--- a/helper/cicheck.go
+++ b/helper/cicheck.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"os"
 	"time"
-
+	
 	"github.com/appknox/appknox-go/appknox"
 	"github.com/appknox/appknox-go/appknox/enums"
+	"github.com/spf13/viper"
 	"github.com/cheynewallace/tabby"
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
@@ -20,6 +21,9 @@ func ProcessCiCheck(fileID, riskThreshold int) {
 	client := getClient()
 	var staticScanProgess int
 	start := time.Now()
+	timeoutMinutes := viper.GetInt("timeout")
+	timeout := time.Duration(timeoutMinutes) * time.Minute
+	fmt.Printf("Starting scan at: %v with timeout of %d minutes\n", start.Format(time.RFC3339), timeoutMinutes)
 	p := mpb.New(
 		mpb.WithWidth(60),
 		mpb.WithRefreshRate(180*time.Millisecond),
@@ -44,7 +48,8 @@ func ProcessCiCheck(fileID, riskThreshold int) {
 		}
 		staticScanProgess = file.StaticScanProgress
 		bar.SetCurrent(int64(staticScanProgess), time.Since(start))
-		if time.Since(start) > 30*time.Minute {
+		
+		if time.Since(start) > timeout {
 			err := errors.New("Request timed out")
 			PrintError(err)
 			os.Exit(1)

--- a/helper/sarif.go
+++ b/helper/sarif.go
@@ -3,13 +3,14 @@ package helper
 import (
 	"fmt"
 	"os"
-
+	"time"
+	
 	"github.com/appknox/appknox-go/appknox"
 )
 
-func ConvertToSARIFReport(fileID int, riskThreshold int, filePath string) error {
+func ConvertToSARIFReport(fileID int, riskThreshold int, filePath string,staticScanTimeout time.Duration) error {
 	client := getClient()
-	sarif, err := appknox.GenerateSARIFGivenFileID(client, fileID, riskThreshold)
+	sarif, err := appknox.GenerateSARIFGivenFileID(client, fileID, riskThreshold,staticScanTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
| Title                          | Value                                                                                     |
| ------------------------------ | ----------------------------------------------------------------------------------------- |
| **Type**                       | Feature                                                |
| **Ticket/Issue**               | https://appknox.atlassian.net/browse/PD-1604                                   |
| **Migrations**                 | No / &lt;apps introducing migrations (eg: `core`, `organization`)&gt;                     |
| **Migration&nbsp;Scripts**     | No / Yes (provide script in description)                                                  |
| **ENV&nbsp;vars&nbsp;change**  | No / &lt;list of env vars added or removed (eg: `APPKNOX_SAMPLE_ENV=local_dev_value`)&gt; |
| **Frontend**                   | No / [&lt;irene PR link&gt;](#)                                                           |
| **Local&nbsp;testing**         | Pending / Done                                                                            |
| **Staging&nbsp;testing**       | Pending / Skip / [&lt;preview link&gt;](#)                                                |
| **On&nbsp;premise&nbsp;notes** | NA / &lt;any notes specific to on premise deployments&gt;                                 |
| **Documentation**              | None / [&lt;Confluence design specification document link&gt;](#)                         |
| **Release&nbsp;notes**         | None / [&lt;Confluence changelog document link&gt;](#)                                    |
| **Version&nbsp;upgrade**       |  Minor                                                                      |

---

### Changelog

1. Added an option to override default 30 mins timeout using cicheck command

---

#### Dependent PRs

-   [Link to vendor#N](#)
-   [Link to k8s](#), etc.