### PR TITLE
Added 5 sec delay in polling loop of upload status and SAST status api's

### DIFF
--- a/appknox/upload.go
+++ b/appknox/upload.go
@@ -105,6 +105,9 @@ func (s *UploadService) CheckSubmission(ctx context.Context, submissionID int) (
 			return nil, nil, errors.New("Request timed out")
 		}
 		fileID = submission.File
+		if fileID == 0 {
+			time.Sleep(5 * time.Second)
+		}
 	}
 	file, resp, err := s.client.Files.GetByID(ctx, fileID)
 	if err != nil {

--- a/helper/cicheck.go
+++ b/helper/cicheck.go
@@ -60,6 +60,7 @@ func ProcessCiCheck(fileID, riskThreshold int, staticScanTimeout time.Duration) 
 			PrintError(err)
 			os.Exit(1)
 		}
+		time.Sleep(5 * time.Second)
 	}
 
 	_, analysisResponse, err := client.Analyses.ListByFile(ctx, fileID, nil)


### PR DESCRIPTION
| Title                          | Value                                                                                     |
| ------------------------------ | ----------------------------------------------------------------------------------------- |
| **Type**                       | Refactor                                                |
| **Ticket/Issue**               | https://appknox.atlassian.net/browse/PD-1981 |                                       
| **Migrations**                 | No |
| **Migration&nbsp;Scripts**     | No |
| **ENV&nbsp;vars&nbsp;change**  | No |
| **Frontend**                   | No |
| **Local&nbsp;testing**         | Done                                                                            |
| **Staging&nbsp;testing**       | Pending                                           |
| **On&nbsp;premise&nbsp;notes** | NA         |
| **Documentation**              | None                    |
| **Release&nbsp;notes**         | None                |
| **Version&nbsp;upgrade**       | Minor                                                                      |

---

### Changelog

1. Add something
Added 5 sec delay in polling loop of upload status and SAST status api's
3. Modify something
    ```python
    sample code
    ```
4. Remove something
    - item 1
    - item 2

---

#### Dependent PRs

-   [Link to vendor#N](#)
-   [Link to k8s](#), etc.