### PR TITLE
added support for ios agent to fetch device info and install packages

### DIFF
--- a/cmd/iosagent.go
+++ b/cmd/iosagent.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/appknox/appknox-go/helper"
+	"github.com/spf13/cobra"
+)
+
+var iosAgentCmd = &cobra.Command{
+	Use:   "iosagent",
+	Short: "iOS device agent for KnoxOps",
+	Long:  "iOS device agent that provides local device detection, pairing, and management over HTTP for the KnoxOps dashboard.",
+}
+
+var iosAgentStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the iOS agent HTTP server",
+	Long: `Start a local HTTP server that exposes iOS device operations
+(detect, pair, fetch info, install/uninstall apps) for the KnoxOps dashboard.
+
+Requires libimobiledevice and ideviceinstaller:
+  brew install libimobiledevice ideviceinstaller`,
+	Run: func(cmd *cobra.Command, args []string) {
+		port, err := cmd.Flags().GetInt("port")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid port: %s\n", err)
+			os.Exit(1)
+		}
+		helper.StartIOSAgent(port)
+	},
+}
+
+func init() {
+	iosAgentStartCmd.Flags().IntP("port", "p", 17392, "Port to run the iOS agent on")
+	iosAgentCmd.AddCommand(iosAgentStartCmd)
+	RootCmd.AddCommand(iosAgentCmd)
+}

--- a/helper/iosagent.go
+++ b/helper/iosagent.go
@@ -1,0 +1,299 @@
+package helper
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const iosAgentVersion = "1.0.0"
+const maxRequestBodySize = 1 << 20 // 1 MB
+
+type deviceIDRequest struct {
+	ID string `json:"id"`
+}
+
+type installRequest struct {
+	ID   string `json:"id"`
+	Path string `json:"path"`
+}
+
+type uninstallRequest struct {
+	ID       string `json:"id"`
+	BundleID string `json:"bundleId"`
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func maxBytesMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"message": msg})
+}
+
+func isToolNotFound(err error) bool {
+	var execErr *exec.Error
+	return errors.As(err, &execErr) && errors.Is(execErr.Err, exec.ErrNotFound)
+}
+
+func toolNotFoundMsg(tool string) string {
+	return fmt.Sprintf("%s not found. Install prerequisites:\n  brew install libimobiledevice ideviceinstaller", tool)
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{
+		"status":  "ok",
+		"version": iosAgentVersion,
+	})
+}
+
+func handleDetect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ids, err := DetectDevice()
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("idevice_id"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(ids) == 0 {
+		writeJSON(w, http.StatusOK, map[string]any{"device": nil})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device": map[string]string{
+			"platform": "ios",
+			"id":       ids[0],
+		},
+	})
+}
+
+func handlePair(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req deviceIDRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if !validateDeviceID(req.ID) {
+		writeError(w, http.StatusBadRequest, "invalid device ID")
+		return
+	}
+	err := PairDevice(req.ID)
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("idevicepair"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+func handleFetch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req deviceIDRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if !validateDeviceID(req.ID) {
+		writeError(w, http.StatusBadRequest, "invalid device ID")
+		return
+	}
+	info, err := FetchDeviceInfo(req.ID)
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("ideviceinfo"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, info)
+}
+
+func handleInstall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req installRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if !validateDeviceID(req.ID) {
+		writeError(w, http.StatusBadRequest, "invalid device ID")
+		return
+	}
+	if err := validateIPAPath(req.Path); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	err := InstallApp(req.ID, req.Path)
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("ideviceinstaller"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+func handleUninstall(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req uninstallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if !validateDeviceID(req.ID) {
+		writeError(w, http.StatusBadRequest, "invalid device ID")
+		return
+	}
+	if !validateBundleID(req.BundleID) {
+		writeError(w, http.StatusBadRequest, "invalid bundle ID")
+		return
+	}
+	err := UninstallApp(req.ID, req.BundleID)
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("ideviceinstaller"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+func handleApps(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req deviceIDRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if !validateDeviceID(req.ID) {
+		writeError(w, http.StatusBadRequest, "invalid device ID")
+		return
+	}
+	apps, err := ListApps(req.ID)
+	if err != nil {
+		if isToolNotFound(err) {
+			writeError(w, http.StatusServiceUnavailable, toolNotFoundMsg("ideviceinstaller"))
+			return
+		}
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"apps": apps})
+}
+
+// newIOSAgentMux creates the HTTP mux with all routes, CORS, and body size limit middleware.
+func newIOSAgentMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handleHealth)
+	mux.HandleFunc("/detect", handleDetect)
+	mux.HandleFunc("/pair", handlePair)
+	mux.HandleFunc("/fetch", handleFetch)
+	mux.HandleFunc("/install", handleInstall)
+	mux.HandleFunc("/uninstall", handleUninstall)
+	mux.HandleFunc("/apps", handleApps)
+	return corsMiddleware(maxBytesMiddleware(mux))
+}
+
+// StartIOSAgent starts the iOS agent HTTP server on the given port.
+// It blocks until interrupted (Ctrl+C / SIGTERM).
+func StartIOSAgent(port int) {
+	if port < 1 || port > 65535 {
+		PrintError(fmt.Sprintf("invalid port: %d (must be 1-65535)", port))
+		os.Exit(1)
+	}
+
+	addr := fmt.Sprintf("localhost:%d", port)
+	handler := newIOSAgentMux()
+
+	fmt.Printf("KnoxOps iOS Agent running on http://%s\n", addr)
+	fmt.Println("Waiting for iOS device connections...")
+	fmt.Println()
+	fmt.Println("Prerequisites:")
+	fmt.Println("  brew install libimobiledevice ideviceinstaller")
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		<-sigCh
+		fmt.Println("\nShutting down iOS Agent...")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		server.Shutdown(ctx)
+	}()
+
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		PrintError(fmt.Sprintf("Failed to start server: %s", err))
+		os.Exit(1)
+	}
+}

--- a/helper/iosagent_test.go
+++ b/helper/iosagent_test.go
@@ -1,0 +1,157 @@
+package helper
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthHandler(t *testing.T) {
+	handler := newIOSAgentMux()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "ok", resp["status"])
+	assert.NotEmpty(t, resp["version"])
+}
+
+func TestDetectHandlerWrongMethod(t *testing.T) {
+	handler := newIOSAgentMux()
+	req := httptest.NewRequest(http.MethodGet, "/detect", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestPairHandlerInvalidID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "id;rm -rf /"})
+	req := httptest.NewRequest(http.MethodPost, "/pair", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPairHandlerMissingID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{})
+	req := httptest.NewRequest(http.MethodPost, "/pair", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestFetchHandlerInvalidID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": ""})
+	req := httptest.NewRequest(http.MethodPost, "/fetch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInstallHandlerMissingPath(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "abc123"})
+	req := httptest.NewRequest(http.MethodPost, "/install", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInstallHandlerNonIPA(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "abc123", "path": "/tmp/app.apk"})
+	req := httptest.NewRequest(http.MethodPost, "/install", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUninstallHandlerMissingBundleID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "abc123"})
+	req := httptest.NewRequest(http.MethodPost, "/uninstall", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUninstallHandlerInvalidBundleID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "abc123", "bundleId": "com.bad;inject"})
+	req := httptest.NewRequest(http.MethodPost, "/uninstall", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAppsHandlerInvalidID(t *testing.T) {
+	handler := newIOSAgentMux()
+	body, _ := json.Marshal(map[string]string{"id": "bad id!"})
+	req := httptest.NewRequest(http.MethodPost, "/apps", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCORSHeaders(t *testing.T) {
+	handler := newIOSAgentMux()
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestCORSHeadersOnRegularRequest(t *testing.T) {
+	handler := newIOSAgentMux()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/helper/iosdevice.go
+++ b/helper/iosdevice.go
@@ -1,0 +1,225 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const defaultCmdTimeout = 10 * time.Second
+
+// DeviceInfo holds parsed iOS device metadata.
+type DeviceInfo struct {
+	Platform     string  `json:"platform"`
+	Name         *string `json:"name"`
+	Model        *string `json:"model"`
+	OSVersion    *string `json:"osVersion"`
+	SerialNumber *string `json:"serialNumber"`
+	UDID         *string `json:"udid"`
+	ModelNumber  *string `json:"modelNumber"`
+	CPUArch      *string `json:"cpuArch"`
+	Colour       *string `json:"colour"`
+	IMEI         *string `json:"imei"`
+	IMEI2        *string `json:"imei2"`
+	MACAddress   *string `json:"macAddress"`
+	SIMNumber    *string `json:"simNumber"`
+	ROM          *string `json:"rom"`
+}
+
+// InstalledApp represents a single installed application.
+type InstalledApp struct {
+	BundleID string `json:"bundleId"`
+	Version  string `json:"version"`
+	Name     string `json:"name"`
+}
+
+var deviceIDRegex = regexp.MustCompile(`^[A-Za-z0-9\-]+$`)
+var bundleIDRegex = regexp.MustCompile(`^[A-Za-z0-9.\-]+$`)
+
+func validateDeviceID(id string) bool {
+	return id != "" && len(id) <= 64 && deviceIDRegex.MatchString(id)
+}
+
+func validateBundleID(id string) bool {
+	return id != "" && len(id) <= 256 && bundleIDRegex.MatchString(id)
+}
+
+func validateIPAPath(path string) error {
+	cleaned := filepath.Clean(path)
+	if !strings.HasSuffix(strings.ToLower(cleaned), ".ipa") {
+		return fmt.Errorf("not an .ipa file")
+	}
+	info, err := os.Lstat(cleaned)
+	if err != nil {
+		return fmt.Errorf("file not found: %s", cleaned)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", cleaned)
+	}
+	return nil
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func parseDeviceList(output string) []string {
+	var ids []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && validateDeviceID(trimmed) {
+			ids = append(ids, trimmed)
+		}
+	}
+	return ids
+}
+
+func parseIdeviceInfo(output string) DeviceInfo {
+	info := DeviceInfo{Platform: "iOS"}
+	for _, line := range strings.Split(output, "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if value == "" {
+			continue
+		}
+		switch key {
+		case "DeviceName":
+			info.Name = strPtr(value)
+		case "ProductType":
+			info.Model = strPtr(value)
+		case "ProductVersion":
+			info.OSVersion = strPtr(value)
+		case "SerialNumber":
+			info.SerialNumber = strPtr(value)
+		case "UniqueDeviceID":
+			info.UDID = strPtr(value)
+		case "ModelNumber":
+			cleaned := strings.Split(value, "/")[0]
+			cleaned = strings.Split(cleaned, "\\")[0]
+			info.ModelNumber = strPtr(strings.TrimSpace(cleaned))
+		case "CPUArchitecture":
+			arch := strings.ToLower(value)
+			switch {
+			case strings.Contains(arch, "arm64") || strings.Contains(arch, "aarch64"):
+				info.CPUArch = strPtr("ARM64")
+			case strings.Contains(arch, "x86_64"):
+				info.CPUArch = strPtr("x86_64")
+			case strings.Contains(arch, "arm"):
+				info.CPUArch = strPtr("ARM")
+			default:
+				info.CPUArch = strPtr(value)
+			}
+		case "InternationalMobileEquipmentIdentity":
+			info.IMEI = strPtr(value)
+		case "IntegratedCircuitCardIdentity":
+			info.SIMNumber = strPtr(value)
+		case "WiFiAddress":
+			info.MACAddress = strPtr(value)
+		case "BuildVersion":
+			info.ROM = strPtr(value)
+		}
+	}
+	return info
+}
+
+func parseInstalledApps(output string) []InstalledApp {
+	var apps []InstalledApp
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		if i == 0 {
+			continue // skip header
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		parts := strings.SplitN(trimmed, ",", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		apps = append(apps, InstalledApp{
+			BundleID: strings.TrimSpace(parts[0]),
+			Version:  strings.Trim(strings.TrimSpace(parts[1]), `"`),
+			Name:     strings.Trim(strings.TrimSpace(parts[2]), `"`),
+		})
+	}
+	return apps
+}
+
+// runCmd executes a command with a timeout and returns stdout.
+func runCmd(cmdName string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCmdTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, cmdName, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// DetectDevice lists connected iOS devices using idevice_id.
+func DetectDevice() ([]string, error) {
+	output, err := runCmd("idevice_id", "-l")
+	if err != nil {
+		return nil, fmt.Errorf("idevice_id: %w", err)
+	}
+	return parseDeviceList(output), nil
+}
+
+// PairDevice pairs/trusts a connected iOS device.
+func PairDevice(deviceID string) error {
+	output, err := runCmd("idevicepair", "-u", deviceID, "pair")
+	if err != nil {
+		return fmt.Errorf("idevicepair: %w", err)
+	}
+	if !strings.Contains(output, "SUCCESS") {
+		return fmt.Errorf("trust not completed — tap \"Trust\" on your iPhone and try again")
+	}
+	return nil
+}
+
+// FetchDeviceInfo retrieves device metadata using ideviceinfo.
+func FetchDeviceInfo(deviceID string) (DeviceInfo, error) {
+	output, err := runCmd("ideviceinfo", "-u", deviceID)
+	if err != nil {
+		return DeviceInfo{Platform: "iOS"}, fmt.Errorf("ideviceinfo: %w", err)
+	}
+	return parseIdeviceInfo(output), nil
+}
+
+// InstallApp installs an IPA on a device using ideviceinstaller.
+func InstallApp(deviceID, ipaPath string) error {
+	_, err := runCmd("ideviceinstaller", "-u", deviceID, "-i", ipaPath)
+	if err != nil {
+		return fmt.Errorf("ideviceinstaller install: %w", err)
+	}
+	return nil
+}
+
+// UninstallApp removes an app by bundle ID using ideviceinstaller.
+func UninstallApp(deviceID, bundleID string) error {
+	_, err := runCmd("ideviceinstaller", "-u", deviceID, "-U", bundleID)
+	if err != nil {
+		return fmt.Errorf("ideviceinstaller uninstall: %w", err)
+	}
+	return nil
+}
+
+// ListApps lists installed apps on a device using ideviceinstaller.
+func ListApps(deviceID string) ([]InstalledApp, error) {
+	output, err := runCmd("ideviceinstaller", "-u", deviceID, "-l")
+	if err != nil {
+		return nil, fmt.Errorf("ideviceinstaller list: %w", err)
+	}
+	return parseInstalledApps(output), nil
+}

--- a/helper/iosdevice_test.go
+++ b/helper/iosdevice_test.go
@@ -1,0 +1,95 @@
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIdeviceInfo(t *testing.T) {
+	output := `ActivationState: Activated
+BuildVersion: 21F90
+CPUArchitecture: arm64e
+DeviceName: My iPhone
+InternationalMobileEquipmentIdentity: 351234567890123
+IntegratedCircuitCardIdentity: 8901234567890123456
+ModelNumber: MQ6M3
+ProductType: iPhone15,2
+ProductVersion: 17.5.1
+SerialNumber: ABCDE12345
+UniqueDeviceID: 00001111-000A1234B567890C
+WiFiAddress: a1:b2:c3:d4:e5:f6`
+
+	info := parseIdeviceInfo(output)
+
+	assert.Equal(t, "iOS", info.Platform)
+	assert.Equal(t, "My iPhone", *info.Name)
+	assert.Equal(t, "iPhone15,2", *info.Model)
+	assert.Equal(t, "17.5.1", *info.OSVersion)
+	assert.Equal(t, "ABCDE12345", *info.SerialNumber)
+	assert.Equal(t, "00001111-000A1234B567890C", *info.UDID)
+	assert.Equal(t, "MQ6M3", *info.ModelNumber)
+	assert.Equal(t, "ARM64", *info.CPUArch)
+	assert.Equal(t, "351234567890123", *info.IMEI)
+	assert.Equal(t, "8901234567890123456", *info.SIMNumber)
+	assert.Equal(t, "a1:b2:c3:d4:e5:f6", *info.MACAddress)
+	assert.Equal(t, "21F90", *info.ROM)
+}
+
+func TestParseIdeviceInfoEmpty(t *testing.T) {
+	info := parseIdeviceInfo("")
+	assert.Equal(t, "iOS", info.Platform)
+	assert.Nil(t, info.Name)
+}
+
+func TestValidateDeviceID(t *testing.T) {
+	assert.True(t, validateDeviceID("00001111-000A1234B567890C"))
+	assert.True(t, validateDeviceID("abcdef1234567890"))
+	assert.False(t, validateDeviceID(""))
+	assert.False(t, validateDeviceID("id;rm -rf /"))
+	assert.False(t, validateDeviceID("id with spaces"))
+}
+
+func TestParseDeviceList(t *testing.T) {
+	output := "00001111-000A1234B567890C\nabcdef1234567890\n"
+	ids := parseDeviceList(output)
+	assert.Equal(t, []string{"00001111-000A1234B567890C", "abcdef1234567890"}, ids)
+}
+
+func TestParseDeviceListEmpty(t *testing.T) {
+	ids := parseDeviceList("")
+	assert.Empty(t, ids)
+}
+
+func TestParseDeviceListFiltersInvalid(t *testing.T) {
+	output := "valid-id-123\n;bad;id;\nok456\n"
+	ids := parseDeviceList(output)
+	assert.Equal(t, []string{"valid-id-123", "ok456"}, ids)
+}
+
+func TestValidateBundleID(t *testing.T) {
+	assert.True(t, validateBundleID("com.example.app"))
+	assert.True(t, validateBundleID("com.another-app.test"))
+	assert.False(t, validateBundleID(""))
+	assert.False(t, validateBundleID("com.bad;app"))
+	assert.False(t, validateBundleID("com.bad app"))
+}
+
+func TestValidateIPAPath(t *testing.T) {
+	assert.Error(t, validateIPAPath(""))
+	assert.Error(t, validateIPAPath("/tmp/app.apk"))
+	assert.Error(t, validateIPAPath("/nonexistent/path/app.ipa"))
+}
+
+func TestParseInstalledApps(t *testing.T) {
+	output := `CFBundleIdentifier, CFBundleVersion, CFBundleDisplayName
+com.example.app, "1.0", "Example App"
+com.another.app, "2.3.1", "Another App"`
+
+	apps := parseInstalledApps(output)
+	assert.Len(t, apps, 2)
+	assert.Equal(t, "com.example.app", apps[0].BundleID)
+	assert.Equal(t, "1.0", apps[0].Version)
+	assert.Equal(t, "Example App", apps[0].Name)
+	assert.Equal(t, "com.another.app", apps[1].BundleID)
+}


### PR DESCRIPTION
| Title                          | Value                                                                                     |
| ------------------------------ | ----------------------------------------------------------------------------------------- |
| **Type**                       | feature/knoxops iOS agent                                             |
| **Ticket/Issue**               | https://appknox.atlassian.net/browse/PD-2237                                        |
| **Migrations**                 | No                    |
| **Migration&nbsp;Scripts**     | No / Yes (provide script in description)                                                  |
| **ENV&nbsp;vars&nbsp;change**  | No |
| **Frontend**                   | No                                                            |
| **Local&nbsp;testing**         |  Done                                                                            |
| **Staging&nbsp;testing**       | Done                                              |
| **On&nbsp;premise&nbsp;notes** | Done                                |
| **Documentation**              | None / [&lt;Confluence design specification document link&gt;](#)                         |
| **Release&nbsp;notes**         | None / [&lt;Confluence changelog document link&gt;](#)                                    |
| **Version&nbsp;upgrade**       | Minor                                                                     |

---

### Changelog

1. Add something
```go
    appknox-go iosagent start
```    


---

#### Dependent PRs

-   [Link to vendor#N](#)
-   [Link to k8s](#), etc.